### PR TITLE
Add Bitcoin Sovereign Academy landing page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Homepage from './components/Homepage';
 import ModuleLayout from './components/ModuleLayout';
 import AboutMe from './components/AboutMe';
 import LessonView from './components/LessonView';
+import BitcoinSovereignAcademy from './pages/BitcoinSovereignAcademy';
 import './styles/globalTheme.css';
 import './styles/hierarchicalSystem.css'; /* Professional visual hierarchy system */
 import './styles/modernComponents.css';
@@ -45,6 +46,7 @@ function App() {
             <Routes>
               <Route path="/" element={<Homepage />} />
               <Route path="/about" element={<ModuleLayout><AboutMe /></ModuleLayout>} />
+              <Route path="/bitcoin-sovereign-academy" element={<BitcoinSovereignAcademy />} />
               
               {/* Module overview routes - Temporary fallback to existing modules */}
               <Route path="/module/wake-up-call" element={<ModuleLayout><MoneyModule /></ModuleLayout>} />

--- a/src/components/Homepage.css
+++ b/src/components/Homepage.css
@@ -31,6 +31,27 @@
   box-sizing: border-box;
 }
 
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.header-nav-link {
+  color: #f0f0f0;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 6px;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.header-nav-link:hover {
+  background: rgba(247, 147, 26, 0.12);
+  color: #f7931a;
+}
+
 .logo-section {
   display: flex;
   align-items: center;

--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -144,9 +144,12 @@ const Homepage = () => {
             </div>
           </div>
           <nav className="header-nav">
+            <Link to="/bitcoin-sovereign-academy" className="header-nav-link">
+              Academy
+            </Link>
             {hasStarted && (
-              <IconButton 
-                onClick={() => setShowResetConfirm(true)} 
+              <IconButton
+                onClick={() => setShowResetConfirm(true)}
                 icon={<RotateCcw size={16} />}
                 tooltip="Reset Progress"
                 size="sm"

--- a/src/pages/BitcoinSovereignAcademy.css
+++ b/src/pages/BitcoinSovereignAcademy.css
@@ -1,0 +1,292 @@
+.academy-page {
+  background: radial-gradient(circle at top, rgba(247, 147, 26, 0.12), transparent 55%), #050505;
+  color: #f5f5f5;
+  min-height: 100vh;
+  padding-bottom: 6rem;
+}
+
+.academy-hero {
+  padding: clamp(3rem, 7vw, 5rem) 1.5rem;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+}
+
+.academy-hero__content {
+  max-width: 880px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.academy-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(247, 147, 26, 0.12);
+  border: 1px solid rgba(247, 147, 26, 0.4);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  color: #f7931a;
+}
+
+.academy-hero h1 {
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  font-weight: 700;
+  margin: 0;
+  color: #ffffff;
+}
+
+.academy-hero p {
+  margin: 0;
+  color: #c5c5c5;
+  line-height: 1.6;
+  font-size: 1.05rem;
+  max-width: 720px;
+}
+
+.academy-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.academy-primary-action .unified-btn__inner {
+  background: linear-gradient(135deg, #f7931a, #ffae42);
+  color: #050505;
+}
+
+.academy-secondary-action {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+}
+
+.academy-secondary-action:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.academy-hero__cta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.95rem;
+  color: #b0b0b0;
+}
+
+.academy-inline-link {
+  color: #f7931a;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.academy-inline-link:hover {
+  text-decoration: underline;
+}
+
+.academy-highlights {
+  padding: clamp(2.5rem, 5vw, 4rem) 1.5rem;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.academy-highlights h2 {
+  text-align: center;
+  margin-bottom: 2.5rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.academy-highlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.academy-highlight-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+
+.academy-highlight-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(247, 147, 26, 0.5);
+  background: rgba(247, 147, 26, 0.12);
+}
+
+.academy-highlight-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.academy-highlight-card p {
+  margin: 0;
+  color: #c5c5c5;
+  line-height: 1.5;
+}
+
+.academy-module-path {
+  padding: clamp(2.5rem, 6vw, 4.5rem) 1.5rem;
+  background: linear-gradient(180deg, rgba(247, 147, 26, 0.07), rgba(5, 5, 5, 0.95));
+}
+
+.academy-section-header {
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+}
+
+.academy-section-header p {
+  color: #c5c5c5;
+  margin-top: 0.75rem;
+  line-height: 1.6;
+}
+
+.academy-module-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.academy-module-group {
+  background: rgba(10, 10, 10, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 40px 80px -40px rgba(0, 0, 0, 0.6);
+}
+
+.academy-module-group__header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.academy-module-emoji {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.academy-module-group__header h3 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.academy-module-group__header p {
+  margin: 0.35rem 0 0;
+  color: #bcbcbc;
+}
+
+.academy-module-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.academy-module-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+  border-radius: 14px;
+  padding: 1.4rem;
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  transition: border-color 0.3s ease, transform 0.3s ease, background 0.3s ease;
+}
+
+.academy-module-card:hover {
+  border-color: rgba(247, 147, 26, 0.6);
+  background: rgba(247, 147, 26, 0.12);
+  transform: translateY(-4px);
+}
+
+.academy-module-card__content h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+}
+
+.academy-module-card__content p {
+  margin: 0;
+  color: #c5c5c5;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.academy-module-card__cta {
+  font-weight: 600;
+  color: #f7931a;
+}
+
+.academy-next-steps {
+  padding: clamp(3rem, 6vw, 4.5rem) 1.5rem 5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.academy-next-steps__content {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 20px;
+  padding: clamp(2rem, 4vw, 3rem);
+  max-width: 760px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.academy-next-steps__content p {
+  margin: 0;
+  color: #c5c5c5;
+  line-height: 1.6;
+}
+
+.academy-next-steps__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.academy-outline-action .unified-btn__inner {
+  background: transparent;
+  border: 1px solid rgba(247, 147, 26, 0.5);
+  color: #f7931a;
+}
+
+@media (max-width: 720px) {
+  .academy-hero__cta {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .academy-module-group {
+    padding: 1.5rem;
+  }
+
+  .academy-module-group__header {
+    flex-direction: column;
+  }
+
+  .academy-module-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/BitcoinSovereignAcademy.jsx
+++ b/src/pages/BitcoinSovereignAcademy.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ActionButton, NavigationButton } from '../components/ui';
+import { moduleGroups, getModulesByGroup } from '../modules/ModuleRegistry';
+import './BitcoinSovereignAcademy.css';
+
+const learningHighlights = [
+  {
+    title: 'Foundations First',
+    description:
+      'Start with the money problem, understand why Bitcoin matters, and build unstoppable conviction in the solution.',
+  },
+  {
+    title: 'Hands-On Mastery',
+    description:
+      'Practice real skills through interactive labs, custody drills, transaction builders, and Bitcoin tooling walkthroughs.',
+  },
+  {
+    title: 'Technical Depth',
+    description:
+      'Dive under the hood with approachable explanations of hashing, mining, scripting, and network architecture.',
+  },
+  {
+    title: 'Advanced Fluency',
+    description:
+      'Finish with Lightning, cutting-edge innovations, and myth-busting context so you can educate others with confidence.',
+  },
+];
+
+const BitcoinSovereignAcademy = () => {
+  const navigate = useNavigate();
+  const sortedGroups = Object.entries(moduleGroups).sort(([, a], [, b]) => a.order - b.order);
+
+  return (
+    <div className="academy-page">
+      <section className="academy-hero">
+        <div className="academy-hero__content">
+          <span className="academy-badge">Bitcoin Sovereign Academy</span>
+          <h1>Own Your Education. Master Your Sovereignty.</h1>
+          <p>
+            The entire Learn Bitcoin by Doing journey is now organized as a guided academy experience. Follow the recommended path
+            or jump directly into the skills you need to become truly sovereign.
+          </p>
+          <div className="academy-hero__actions">
+            <ActionButton
+              size="lg"
+              priority="high"
+              onClick={() => navigate('/?view=learning')}
+              className="academy-primary-action"
+            >
+              Start Learning
+            </ActionButton>
+            <NavigationButton
+              size="lg"
+              direction="forward"
+              onClick={() => {
+                const section = document.getElementById('module-path');
+                if (section) {
+                  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                } else {
+                  navigate('/bitcoin-sovereign-academy#module-path');
+                }
+              }}
+              className="academy-secondary-action"
+            >
+              Explore the Path
+            </NavigationButton>
+          </div>
+          <div className="academy-hero__cta">
+            <span>Just want the quick overview?</span>
+            <Link to="/bitcoin-first-principles.html" className="academy-inline-link">
+              Read the manifesto
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="academy-highlights">
+        <h2>Your Sovereign Learning Journey</h2>
+        <div className="academy-highlight-grid">
+          {learningHighlights.map((item) => (
+            <div key={item.title} className="academy-highlight-card">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="module-path" className="academy-module-path">
+        <header className="academy-section-header">
+          <h2>Follow the Academy Path</h2>
+          <p>
+            Each phase builds on the last. Complete them in order for a curated experience, or choose individual modules to fill
+            specific knowledge gaps.
+          </p>
+        </header>
+        <div className="academy-module-groups">
+          {sortedGroups.map(([groupId, group]) => {
+            const modules = getModulesByGroup(groupId);
+            return (
+              <div key={groupId} className="academy-module-group">
+                <div className="academy-module-group__header">
+                  <span className="academy-module-emoji" aria-hidden="true">
+                    {group.emoji}
+                  </span>
+                  <div>
+                    <h3>{group.title}</h3>
+                    <p>{group.description}</p>
+                  </div>
+                </div>
+                <div className="academy-module-list">
+                  {modules.map((module) => (
+                    <Link key={module.id} to={`/module/${module.id}`} className="academy-module-card">
+                      <div className="academy-module-card__content">
+                        <h4>{module.title}</h4>
+                        <p>{module.description}</p>
+                      </div>
+                      <span className="academy-module-card__cta" aria-hidden="true">
+                        Start →
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="academy-next-steps">
+        <div className="academy-next-steps__content">
+          <h2>Continue Building Sovereignty</h2>
+          <p>
+            Track your progress, unlock achievements, and revisit modules any time from the homepage dashboard. The academy keeps
+            everything organized so your learning momentum never stalls.
+          </p>
+          <div className="academy-next-steps__actions">
+            <ActionButton size="md" onClick={() => navigate('/?view=progress')}>
+              View My Progress
+            </ActionButton>
+            <ActionButton
+              size="md"
+              variant="secondary"
+              onClick={() => navigate('/?view=learning')}
+              className="academy-outline-action"
+            >
+              Return to Dashboard
+            </ActionButton>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default BitcoinSovereignAcademy;


### PR DESCRIPTION
## Summary
- add a dedicated Bitcoin Sovereign Academy overview page that highlights the guided learning path
- style the academy experience with responsive sections and call-to-action components
- expose the new page through the router and homepage header navigation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d986a2f9c083278fe160fe53b693ee